### PR TITLE
added a few more drawImage function overloads

### DIFF
--- a/src/include/Image.cpp
+++ b/src/include/Image.cpp
@@ -68,6 +68,52 @@ bool Image::drawImage(const uint8_t *buf, int x, int y, int16_t w, int16_t h, ui
     return 1;
 }
 
+bool Image::drawImage(const String path, const Format& format, const int x, const int y, const bool dither, const bool invert)
+{
+    return drawImage(path.c_str(), format, x, y, dither, invert);
+};
+
+bool Image::drawImage(const char *path, const Format& format, const int x, const int y, const bool dither, const bool invert)
+{
+    if (strncmp(path, "http://", 7) == 0 || strncmp(path, "https://", 8) == 0)
+    {
+        if (format == BMP)
+            return drawBitmapFromWeb(path, x, y, dither, invert);
+        if (format == JPG)
+            return drawJpegFromWeb(path, x, y, dither, invert);
+        if (format == PNG)
+            return drawPngFromWeb(path, x, y, dither, invert);
+    }
+    else
+    {
+        if (format == BMP)
+            return drawBitmapFromSd(path, x, y, dither, invert);
+        if (format == JPG)
+            return drawJpegFromSd(path, x, y, dither, invert);
+        if (format == PNG)
+            return drawPngFromSd(path, x, y, dither, invert);
+    }
+    return 0;
+}
+
+bool Image::drawImage(const char* path, const Format& format, const Position& position, const bool dither, const bool invert) {
+    if (strncmp(path, "http://", 7) == 0 || strncmp(path, "https://", 8) == 0)
+    {
+        if (format == JPG)
+            return drawJpegFromWebAtPosition(path, position, dither, invert);
+
+        //TODO: implement
+        return false;
+    }
+    else
+    {
+        //TODO: implement
+        return false;
+    }
+    return false;
+}
+
+
 void Image::drawBitmap3Bit(int16_t _x, int16_t _y, const unsigned char *_p, int16_t _w, int16_t _h)
 {
     if (getDisplayMode() != INKPLATE_3BIT)

--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -27,6 +27,22 @@ Distributed as-is; no warranty is given.
 class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 {
   public:
+    typedef enum
+    {
+        BMP,
+        JPG,
+        PNG
+    } Format;
+
+    typedef enum
+    {
+        Center,
+        TopLeft,
+        BottomLeft,
+        TopRight,
+        BottomRight
+    } Position;
+	
     Image(int16_t w, int16_t h);
 
     virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
@@ -39,6 +55,9 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
     bool drawImage(const char *path, int x, int y, bool dither = 1, bool invert = 0);
     bool drawImage(const String path, int x, int y, bool dither = 1, bool invert = 0);
     bool drawImage(const uint8_t *buf, int x, int y, int16_t w, int16_t h, uint8_t c = BLACK, uint8_t bg = 0xFF);
+    bool drawImage(const char *path, const Format& format, const int x, const int y, const bool dither = 1, const bool invert = 0);
+    bool drawImage(const String path, const Format& format, const int x, const int y, const bool dither = 1, const bool invert = 0);
+    bool drawImage(const char* path, const Format& format, const Position& position, const bool dither = 1, const bool invert = 0);	
 
     // Defined in Adafruit-GFX-Library, but should fit here
     // void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
@@ -113,6 +132,11 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
     void readBmpHeaderSd(SdFile *_f, bitmapHeader *_h);
 
     inline void displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool dither, bool invert);
+
+    void getPointsForPosition(const Position& position, const uint16_t imageWidth, const uint16_t imageHeight, 
+		const uint16_t screenWidth, const uint16_t screenHeight, uint16_t *posX, uint16_t *posY);
+
+    bool drawJpegFromWebAtPosition(const char* url, const Position& position, const bool dither = 0, const bool invert = 0);
 
     // FUTURE COMPATIBILITY FUNCTIONS; DO NOT USE!
 

--- a/src/include/ImageJPEG.cpp
+++ b/src/include/ImageJPEG.cpp
@@ -84,6 +84,32 @@ bool Image::drawJpegFromWeb(const char *url, int x, int y, bool dither, bool inv
     return ret;
 }
 
+bool Image::drawJpegFromWebAtPosition(const char *url, const Position& position, const bool dither, const bool invert)
+{
+    bool ret = 0;
+
+    int32_t defaultLen = 800 * 600 * 4;
+    uint8_t *buff = downloadFile(url, &defaultLen);
+
+    uint16_t w = 0;
+    uint16_t h = 0;
+    TJpgDec.setJpgScale(1);
+    JRESULT r = TJpgDec.getJpgSize(&w, &h, buff, defaultLen);
+    if(r != JDR_OK) {
+        free(buff);
+        return false;
+    }
+
+    uint16_t posX, posY;
+    getPointsForPosition(position, w, h, 800, 600, &posX, &posY);
+
+    ret = drawJpegFromBuffer(buff, defaultLen, posX, posY, dither, invert);
+    free(buff);
+
+    return ret;
+}
+
+
 bool Image::drawJpegFromWeb(WiFiClient *s, int x, int y, int32_t len, bool dither, bool invert)
 {
     bool ret = 0;

--- a/src/include/ImageUtils.cpp
+++ b/src/include/ImageUtils.cpp
@@ -1,0 +1,36 @@
+#include "Image.h"
+
+void Image::getPointsForPosition(const Position& position, const uint16_t imageWidth, const uint16_t imageHeight, 
+	const uint16_t screenWidth, const uint16_t screenHeight, uint16_t *posX, uint16_t *posY)
+{
+	*posX = 0;
+	*posY = 0;
+
+	switch(position) {
+		case TopLeft:
+			break;
+		case Center:
+			if(imageWidth < screenWidth)
+				*posX = (screenWidth - imageWidth) >> 1; 
+			
+			if(imageHeight < screenHeight)
+				*posY = (screenHeight - imageHeight) >> 1;	
+			break;
+		case BottomLeft:
+			if(imageHeight < screenHeight)
+				*posY = screenHeight - imageHeight;
+			break;
+		case TopRight:
+			if(imageWidth < screenWidth)
+				*posX = screenWidth - imageWidth; 
+			break;
+		case BottomRight:
+			if(imageWidth < screenWidth)
+				*posX = screenWidth - imageWidth;
+			if(imageHeight < screenHeight)
+				*posY = screenHeight - imageHeight;
+			break;
+		default:
+			break;
+	}
+}


### PR DESCRIPTION
* The existing drawImage function determined the image type by looking
at the file ending. However, that only works in case the image that's going
to be displayed has a file ending. This changeset adds the possibility
to explicitly specify the format (BMP, JPG, PNG).

* Added the possibility to specify the position (Center, TopLeft,
BottomLeft, TopRight, BottomRight) of the image on the screen. This
function overload is purely for convenience and makes it easier to
position the image on the screen without needing to specify the x and y
pos. Currently, only jpg images fetched from web can be positioned that
way; for every other image format and source (e.g SD card),
the appropriate functionality still needs to be implemented.


As discussed in #48, I've tried to implement a few functions that I personally would find pretty convenient. I've only implemented the functionality that I need, so in order to be feature complete, there are definitely some changes needed. Not sure if the API is the way you imagined it. Feedback & suggestions are highly appreciated. 