### PR TITLE
UriBraces is need to make Inkplate_Web_Server works

### DIFF
--- a/examples/Inkplate_10/Advanced_Inkplate_Features/Inkplate_Web_Server/Inkplate_Web_Server.ino
+++ b/examples/Inkplate_10/Advanced_Inkplate_Features/Inkplate_Web_Server/Inkplate_Web_Server.ino
@@ -28,6 +28,7 @@
 #include <WebServer.h>  //Include ESP32 library for Web server
 #include <WiFi.h>       //Include ESP32 WiFi library
 #include <WiFiClient.h> //Include ESP32 WiFi library for AP
+#include <uri/UriBraces.h>
 
 #define ssid "Inkplate"
 #define pass "e-radionica"
@@ -54,7 +55,7 @@ void setup()
     serverIP = WiFi.softAPIP(); // Get the server IP address
 
     server.on("/", handleRoot); // If you open homepage, go to handle root function
-    server.on("/string/{}",
+    server.on(UriBraces("/string/{}"),
               handleString); // If you send some text to Inkplate, go to handleString function. Note that {} brackets at
                              // the end of address. That means that web address has some arguments (our text!).
     server.begin();          // Start the web server

--- a/examples/Inkplate_6/Advanced_Inkplate_Features/Inkplate_Web_Server/Inkplate_Web_Server.ino
+++ b/examples/Inkplate_6/Advanced_Inkplate_Features/Inkplate_Web_Server/Inkplate_Web_Server.ino
@@ -28,6 +28,7 @@
 #include <WebServer.h>  //Include ESP32 library for Web server
 #include <WiFi.h>       //Include ESP32 WiFi library
 #include <WiFiClient.h> //Include ESP32 WiFi library for AP
+#include <uri/UriBraces.h>
 
 #define ssid "Inkplate"
 #define pass "e-radionica"
@@ -54,7 +55,7 @@ void setup()
     serverIP = WiFi.softAPIP(); // Get the server IP address
 
     server.on("/", handleRoot); // If you open homepage, go to handle root function
-    server.on("/string/{}",
+    server.on(UriBraces("/string/{}"),
               handleString); // If you send some text to Inkplate, go to handleString function. Note that {} brackets at
                              // the end of address. That means that web address has some arguments (our text!).
     server.begin();          // Start the web server


### PR DESCRIPTION
Without UriBraces for `server.on("/string/{}")`, submiting the form failed 404 not found.

I found it from here
https://github.com/espressif/arduino-esp32/blob/46d5afb17fb91965632dc5fef237117e1fe947fc/libraries/WebServer/examples/PathArgServer/PathArgServer.ino#L39

Tested on Inkplate6. I don't have Inkplate10, but it should work as well.