### PR TITLE
Simplify inheritance structure

### DIFF
--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -31,7 +31,7 @@
 /**
  * @brief       Image basic class for work with images
  */
-class Image : virtual public NetworkClient, virtual public Adafruit_GFX
+class Image : virtual public Adafruit_GFX
 {
   public:
     typedef enum

--- a/src/include/ImageBMP.cpp
+++ b/src/include/ImageBMP.cpp
@@ -206,7 +206,7 @@ bool Image::drawBitmapFromWeb(const char *url, int x, int y, bool dither, bool i
 {
     bool ret = 0;
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4 + 150;
-    uint8_t *buf = downloadFile(url, &defaultLen);
+    uint8_t *buf = NetworkClient::downloadFile(url, &defaultLen);
 
     ret = drawBitmapFromBuffer(buf, x, y, dither, invert);
     free(buf);
@@ -235,7 +235,7 @@ bool Image::drawBitmapFromWeb(const char *url, int x, int y, bool dither, bool i
 bool Image::drawBitmapFromWeb(WiFiClient *s, int x, int y, int32_t len, bool dither, bool invert)
 {
     bool ret = 0;
-    uint8_t *buf = downloadFile(s, len);
+    uint8_t *buf = NetworkClient::downloadFile(s, len);
 
     ret = drawBitmapFromBuffer(buf, x, y, dither, invert);
     free(buf);
@@ -471,7 +471,7 @@ bool Image::drawBmpFromWebAtPosition(const char *url, const Position &position, 
 {
     bool ret = 0;
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4 + 150;
-    uint8_t *buf = downloadFile(url, &defaultLen);
+    uint8_t *buf = NetworkClient::downloadFile(url, &defaultLen);
 
     bitmapHeader bmpHeader;
     readBmpHeader(buf, &bmpHeader);

--- a/src/include/ImageJPEG.cpp
+++ b/src/include/ImageJPEG.cpp
@@ -122,7 +122,7 @@ bool Image::drawJpegFromWeb(const char *url, int x, int y, bool dither, bool inv
     bool ret = 0;
 
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4;
-    uint8_t *buff = downloadFile(url, &defaultLen);
+    uint8_t *buff = NetworkClient::downloadFile(url, &defaultLen);
 
     ret = drawJpegFromBuffer(buff, defaultLen, x, y, dither, invert);
     free(buff);
@@ -149,7 +149,7 @@ bool Image::drawJpegFromWebAtPosition(const char *url, const Position &position,
     bool ret = 0;
 
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4;
-    uint8_t *buff = downloadFile(url, &defaultLen);
+    uint8_t *buff = NetworkClient::downloadFile(url, &defaultLen);
 
     uint16_t w = 0;
     uint16_t h = 0;
@@ -263,7 +263,7 @@ bool Image::drawJpegFromSdAtPosition(const char *fileName, const Position &posit
 bool Image::drawJpegFromWeb(WiFiClient *s, int x, int y, int32_t len, bool dither, bool invert)
 {
     bool ret = 0;
-    uint8_t *buff = downloadFile(s, len);
+    uint8_t *buff = NetworkClient::downloadFile(s, len);
     ret = drawJpegFromBuffer(buff, len, x, y, dither, invert);
     free(buff);
 

--- a/src/include/ImagePNG.cpp
+++ b/src/include/ImagePNG.cpp
@@ -211,7 +211,7 @@ bool Image::drawPngFromWeb(const char *url, int x, int y, bool dither, bool inve
     pngle_set_draw_callback(pngle, pngle_on_draw);
 
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4 + 100;
-    uint8_t *buff = downloadFile(url, &defaultLen);
+    uint8_t *buff = NetworkClient::downloadFile(url, &defaultLen);
 
     if (!buff)
         return 0;
@@ -264,7 +264,7 @@ bool Image::drawPngFromWeb(WiFiClient *s, int x, int y, int32_t len, bool dither
     _pngY = y;
     pngle_set_draw_callback(pngle, pngle_on_draw);
 
-    uint8_t *buff = downloadFile(s, len);
+    uint8_t *buff = NetworkClient::downloadFile(s, len);
 
     if (!buff)
         return 0;
@@ -307,7 +307,7 @@ bool Image::drawPngFromWebAtPosition(const char *url, const Position &position, 
     pngle_set_draw_callback(pngle, pngle_on_draw);
 
     int32_t defaultLen = E_INK_WIDTH * E_INK_HEIGHT * 4 + 100;
-    uint8_t *buff = downloadFile(url, &defaultLen);
+    uint8_t *buff = NetworkClient::downloadFile(url, &defaultLen);
 
     if (!buff)
         return 0;

--- a/src/include/NetworkClient.h
+++ b/src/include/NetworkClient.h
@@ -41,15 +41,18 @@ struct bitmapHeader
 /**
  * @brief       NetworkClient class that holds standard functions for working with network
  */
-class NetworkClient
+class NetworkClient final
 {
   public:
-    bool joinAP(const char *ssid, const char *pass);
-    void disconnect();
-    bool isConnected();
+    NetworkClient() = delete;
+    ~NetworkClient() = delete;
 
-    uint8_t *downloadFile(const char *url, int32_t *defaultLen);
-    uint8_t *downloadFile(WiFiClient *url, int32_t len);
+    static bool joinAP(const char *ssid, const char *pass);
+    static void disconnect();
+    static bool isConnected();
+
+    static uint8_t *downloadFile(const char *url, int32_t *defaultLen);
+    static uint8_t *downloadFile(WiFiClient *url, int32_t len);
 
   private:
 };

--- a/src/include/System.h
+++ b/src/include/System.h
@@ -22,9 +22,7 @@
 #include "Arduino.h"
 #include "SPI.h"
 
-#include "Esp.h"
 #include "Mcp.h"
-#include "NetworkClient.h"
 
 #ifdef ARDUINO_INKPLATE6PLUS
 #include "Frontlight.h"
@@ -36,13 +34,10 @@
 /**
  * @brief       System class for interaction with panel harware
  */
-class System : public Esp,
-               virtual public Mcp,
-               virtual public NetworkClient
+class System : virtual public Mcp
 #ifdef ARDUINO_INKPLATE6PLUS
-    ,
-               public Touch,
-               public Frontlight
+               , public Touch
+               , public Frontlight
 #endif
 {
   public:


### PR DESCRIPTION
Convert NetworkClient into a pure static helper class and do not use for inheritance.
In my opinion this makes the code easier to comprehend.
Let me know if you are interested in these kind of changes. I think there is potential for some more similar changes.
Cheers