### PR TITLE
fixes touchpad wake examples

### DIFF
--- a/examples/Inkplate10/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
+++ b/examples/Inkplate10/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
@@ -24,10 +24,11 @@
 // Time ESP32 will go to sleep (in seconds)
 #define TIME_TO_SLEEP 30
 
+// bitmask for GPIO_34 which is connected to MCP INTB
+#define TOUCHPAD_WAKE_MASK (int64_t(1)<<GPIO_NUM_34)
+
 // Initiate Inkplate object
 Inkplate display(INKPLATE_1BIT);
-
-byte touchPadPin = 10;
 
 // Store int in rtc data, to remain persistent during deep sleep
 RTC_DATA_ATTR int bootCount = 0;
@@ -38,24 +39,24 @@ void setup()
     display.begin();
 
     // Setup mcp interrupts
-    display.pinModeInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, INPUT);
     display.setIntOutputInternal(MCP23017_INT_ADDR, display.mcpRegsInt, 1, false, false, HIGH);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD1, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD2, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD3, RISING);
 
     ++bootCount;
 
     // Our function declared below
     displayInfo();
 
-    // Go to sleep for TIME_TO_SLEEP seconds, but also enable wake up from gpio 34
-    // Gpio 34 is where the mcp interrupt is connected, check
-    // https://github.com/e-radionicacom/Inkplate-6-hardware/blob/master/Schematics%2C%20Gerber%2C%20BOM/Inkplate6%20Schematics.pdf
-    // for more detail
+    // Go to sleep for TIME_TO_SLEEP seconds
     esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_34, 1);
 
-    // Enable wakup from deep sleep on gpio 36
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, 0);
+    // Enable wakeup from deep sleep on gpio 36 (wake button)
+    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, LOW);
+
+    // enable wake from MCP port expander on gpio 34
+    esp_sleep_enable_ext1_wakeup(TOUCHPAD_WAKE_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
 
     // Go to sleep
     esp_deep_sleep_start();

--- a/examples/Inkplate5/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
+++ b/examples/Inkplate5/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
@@ -24,10 +24,11 @@
 // Time ESP32 will go to sleep (in seconds)
 #define TIME_TO_SLEEP 30
 
+// bitmask for GPIO_34 which is connected to MCP INTB
+#define TOUCHPAD_WAKE_MASK (int64_t(1)<<GPIO_NUM_34)
+
 // Initiate Inkplate object
 Inkplate display(INKPLATE_1BIT);
-
-byte touchPadPin = 10;
 
 // Store int in rtc data, to remain persistent during deep sleep
 RTC_DATA_ATTR int bootCount = 0;
@@ -38,24 +39,24 @@ void setup()
     display.begin();
 
     // Setup mcp interrupts
-    display.pinModeInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, INPUT);
     display.setIntOutputInternal(MCP23017_INT_ADDR, display.mcpRegsInt, 1, false, false, HIGH);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD1, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD2, RISING);
+    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD3, RISING);
 
     ++bootCount;
 
     // Our function declared below
     displayInfo();
 
-    // Go to sleep for TIME_TO_SLEEP seconds, but also enable wake up from gpio 34
-    // Gpio 34 is where the mcp interrupt is connected, check
-    // https://github.com/e-radionicacom/Inkplate-6-hardware/blob/master/Schematics%2C%20Gerber%2C%20BOM/Inkplate6%20Schematics.pdf
-    // for more detail
+    // Go to sleep for TIME_TO_SLEEP seconds
     esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_34, 1);
 
-    // GPIO 36 is where the wake up button is connected
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, 0);
+    // Enable wakeup from deep sleep on gpio 36 (wake button)
+    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, LOW);
+
+    // enable wake from MCP port expander on gpio 34
+    esp_sleep_enable_ext1_wakeup(TOUCHPAD_WAKE_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
 
     // Go to sleep
     esp_deep_sleep_start();

--- a/examples/Inkplate6/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
+++ b/examples/Inkplate6/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
@@ -24,10 +24,11 @@
 // Time ESP32 will go to sleep (in seconds)
 #define TIME_TO_SLEEP 30
 
+// bitmask for GPIO_34 which is connected to MCP INTB
+#define TOUCHPAD_WAKE_MASK (int64_t(1)<<GPIO_NUM_34)
+
 // Initiate Inkplate object
 Inkplate display(INKPLATE_1BIT);
-
-byte touchPadPin = PAD1;
 
 // Store int in rtc data, to remain persistent during deep sleep
 RTC_DATA_ATTR int bootCount = 0;
@@ -38,21 +39,24 @@ void setup()
     display.begin();
 
     // Setup mcp interrupts
-    display.pinModeInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, INPUT);
     display.setIntOutput(1, false, false, HIGH);
-    display.setIntPin(touchPadPin, RISING);
+    display.setIntPin(PAD1, RISING);
+    display.setIntPin(PAD2, RISING);
+    display.setIntPin(PAD3, RISING);
 
     ++bootCount;
 
     // Our function declared below
     displayInfo();
 
-    // Go to sleep for TIME_TO_SLEEP seconds, but also enable wake up from gpio 34
-    // Gpio 34 is where the mcp interrupt is connected, check
-    // https://github.com/e-radionicacom/Inkplate-6-hardware/blob/master/Schematics%2C%20Gerber%2C%20BOM/Inkplate6%20Schematics.pdf
-    // for more detail
+    // Go to sleep for TIME_TO_SLEEP seconds
     esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_34, 1);
+
+    // Enable wakeup from deep sleep on gpio 36 (wake button)
+    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, LOW);
+
+    // enable wake from MCP port expander on gpio 34
+    esp_sleep_enable_ext1_wakeup(TOUCHPAD_WAKE_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
 
     // Go to sleep
     esp_deep_sleep_start();

--- a/examples/Inkplate6COLOR/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
+++ b/examples/Inkplate6COLOR/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
@@ -24,10 +24,11 @@
 // Time ESP32 will go to sleep (in seconds)
 #define TIME_TO_SLEEP 30
 
+// bitmask for GPIO_34 which is connected to MCP INTB
+#define TOUCHPAD_WAKE_MASK (int64_t(1)<<GPIO_NUM_34)
+
 // Initiate Inkplate object
 Inkplate display;
-
-byte touchPadPin = PAD1;
 
 // Store int in rtc data, to remain persistent during deep sleep
 RTC_DATA_ATTR int bootCount = 0;
@@ -38,24 +39,24 @@ void setup()
     display.begin();
 
     // Setup mcp interrupts
-    display.pinModeInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, INPUT);
     display.setIntOutput(1, false, false, HIGH);
-    display.setIntPin(touchPadPin, RISING);
+    display.setIntPin(PAD1, RISING);
+    display.setIntPin(PAD2, RISING);
+    display.setIntPin(PAD3, RISING);
 
     ++bootCount;
 
     // Our function declared below
     displayInfo();
 
-    // Go to sleep for TIME_TO_SLEEP seconds, but also enable wake up from gpio 34
-    // Gpio 34 is where the mcp interrupt is connected, check
-    // https://github.com/e-radionicacom/Inkplate-6-hardware/blob/master/Schematics%2C%20Gerber%2C%20BOM/Inkplate6%20Schematics.pdf
-    // for more detail
+    // Go to sleep for TIME_TO_SLEEP seconds
     esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_34, 1);
 
-    // Enable wakup from deep sleep on gpio 36
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, 0);
+    // Enable wakeup from deep sleep on gpio 36 (wake button)
+    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, LOW);
+
+    // enable wake from MCP port expander on gpio 34
+    esp_sleep_enable_ext1_wakeup(TOUCHPAD_WAKE_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
 
     // Go to sleep
     esp_deep_sleep_start();

--- a/examples/Inkplate6PLUS/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
+++ b/examples/Inkplate6PLUS/Advanced_Inkplate_Features/Inkplate_Wake_Up_On_Touchpads/Inkplate_Wake_Up_On_Touchpads.ino
@@ -24,10 +24,11 @@
 // Time ESP32 will go to sleep (in seconds)
 #define TIME_TO_SLEEP 30
 
+// bitmask for GPIO_34 which is connected to MCP INTB
+#define TOUCHPAD_WAKE_MASK (int64_t(1)<<GPIO_NUM_34)
+
 // Initiate Inkplate object
 Inkplate display(INKPLATE_1BIT);
-
-byte touchPadPin = PAD1;
 
 // Store int in rtc data, to remain persistent during deep sleep
 RTC_DATA_ATTR int bootCount = 0;
@@ -38,24 +39,25 @@ void setup()
     display.begin();
 
     // Setup mcp interrupts
-    display.pinModeInternal(MCP23017_INT_ADDR, display.mcpRegsInt, touchPadPin, INPUT);
     display.setIntOutput(1, false, false, HIGH);
-    display.setIntPin(touchPadPin, RISING);
+    display.setIntPin(PAD1, RISING);
+    display.setIntPin(PAD2, RISING);
+    display.setIntPin(PAD3, RISING);
+
 
     ++bootCount;
 
     // Our function declared below
     displayInfo();
 
-    // Go to sleep for TIME_TO_SLEEP seconds, but also enable wake up from gpio 34
-    // Gpio 34 is where the mcp interrupt is connected, check
-    // https://github.com/e-radionicacom/Inkplate-6-hardware/blob/master/Schematics%2C%20Gerber%2C%20BOM/Inkplate6%20Schematics.pdf
-    // for more detail
+    // Go to sleep for TIME_TO_SLEEP seconds
     esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_34, 1);
 
-    // Enable wakup from deep sleep on gpio 36
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, 0);
+    // Enable wakeup from deep sleep on gpio 36 (wake button)
+    esp_sleep_enable_ext0_wakeup(GPIO_NUM_36, LOW);
+
+    // enable wake from MCP port expander on gpio 34
+    esp_sleep_enable_ext1_wakeup(TOUCHPAD_WAKE_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
 
     // Go to sleep
     esp_deep_sleep_start();


### PR DESCRIPTION
Fixes #119.

I only have an Inkplate10 so that was the only example I was able to test/verify. But I did check the schematics and definitions for the other boards and think the rest of the examples should work as well.