### PR TITLE
Fix preloading of screen for larger Inkplate 10 

### DIFF
--- a/src/Inkplate.cpp
+++ b/src/Inkplate.cpp
@@ -77,7 +77,7 @@ void Inkplate::display(bool leaveOn)
  */
 void Inkplate::preloadScreen()
 {
-    memcpy(DMemoryNew, _partial, 60000);
+    memcpy(DMemoryNew, _partial, 123750);
 }
 
 /**


### PR DESCRIPTION
There is an issue if you use deep-sleep + partial-update on an Inkplate 10 device, which results in a screen that is only "updated" for one half of the screen (see here: https://forum.e-radionica.com/en/viewtopic.php?f=22&t=426).

This fix increases the number of bytes to copy when preloading the screen so that it matches to the whole screen of an Inkplate 10 device.