### PR TITLE
Change ARDUINO_ESP32_DEV define to ARDUINO_INKPLATE6

### DIFF
--- a/src/boards/Inkplate10.cpp
+++ b/src/boards/Inkplate10.cpp
@@ -64,7 +64,7 @@ bool Inkplate::begin()
                     (((i & B11100000) >> 5) << 25);
 #endif
 
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, HIGH);
 #else
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, LOW);

--- a/src/boards/Inkplate6.cpp
+++ b/src/boards/Inkplate6.cpp
@@ -24,7 +24,7 @@
 #include "../include/Graphics.h"
 #include "../include/defines.h"
 
-#if (defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6V2))
+#if (defined(ARDUINO_INKPLATE6) || defined(ARDUINO_INKPLATE6V2))
 
 /**
  * @brief       begin function initialize Inkplate object with predefined
@@ -44,7 +44,7 @@ bool Inkplate::begin(void)
         pinLUT[i] = ((i & B00000011) << 4) | (((i & B00001100) >> 2) << 18) | (((i & B00010000) >> 4) << 23) |
                     (((i & B11100000) >> 5) << 25);
 
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, HIGH);
 #else
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, LOW);
@@ -250,7 +250,7 @@ void Inkplate::display1b(bool leaveOn)
     clean(2, 1);
 
 // How many cycles / phases / frames of dark pixels
-#if defined(ARDUINO_ESP32_DEV)
+#if defined(ARDUINO_INKPLATE6)
     int rep = 4;
 #elif defined(ARDUINO_INKPLATE6V2)
     int rep = 5;
@@ -284,7 +284,7 @@ void Inkplate::display1b(bool leaveOn)
                 GPIO.out_w1tc = DATA | CL;
             }
 // New Inkplate6 panel doesn't need last clock
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
             GPIO.out_w1ts = CL;
             GPIO.out_w1tc = DATA | CL;
 #endif
@@ -320,7 +320,7 @@ void Inkplate::display1b(bool leaveOn)
             _pos--;
         }
 // New Inkplate6 panel doesn't need last clock
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
         GPIO.out_w1ts = CL;
         GPIO.out_w1tc = DATA | CL;
 #endif
@@ -346,7 +346,7 @@ void Inkplate::display1b(bool leaveOn)
             GPIO.out_w1tc = DATA | CL;
         }
 // New Inkplate6 panel doesn't need last clock
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
         GPIO.out_w1ts = CL;
         GPIO.out_w1tc = DATA | CL;
 #endif
@@ -411,7 +411,7 @@ void Inkplate::display3b(bool leaveOn)
                 GPIO.out_w1tc = DATA | CL;
             }
 // New Inkplate6 panel doesn't need last clock
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
             GPIO.out_w1ts = CL;
             GPIO.out_w1tc = DATA | CL;
 #endif
@@ -488,7 +488,7 @@ uint32_t Inkplate::partialUpdate(bool _forced, bool leaveOn)
         return 0;
 
 // How many cycles / phases / frames to write to the panel.
-#if defined(ARDUINO_ESP32_DEV)
+#if defined(ARDUINO_INKPLATE6)
     int rep = 5;
 #elif defined(ARDUINO_INKPLATE6V2)
     int rep = 6;
@@ -513,7 +513,7 @@ uint32_t Inkplate::partialUpdate(bool _forced, bool leaveOn)
                 n--;
             }
 // New Inkplate6 panel doesn't need last clock
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
             GPIO.out_w1ts = CL;
             GPIO.out_w1tc = DATA | CL;
 #endif

--- a/src/boards/Inkplate6.h
+++ b/src/boards/Inkplate6.h
@@ -20,7 +20,7 @@
 #ifndef INKPLATE6_H
 #define INKPLATE6_H
 
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
 #define IO_INT_ADDR 0x20
 #define IO_EXT_ADDR 0x22
 #endif
@@ -37,7 +37,7 @@
 #define E_INK_HEIGHT 600
 
 // Last element (index = 8) in waveform array is not used!
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
 #define WAVEFORM3BIT                                                                                                   \
     {{0, 1, 1, 0, 0, 1, 1, 0, 0}, {0, 1, 2, 1, 1, 2, 1, 0, 0}, {1, 1, 1, 2, 2, 1, 0, 0, 0},                            \
      {0, 0, 0, 1, 1, 1, 2, 0, 0}, {2, 1, 1, 1, 2, 1, 2, 0, 0}, {2, 2, 1, 1, 2, 1, 2, 0, 0},                            \

--- a/src/boards/Inkplate6plus.cpp
+++ b/src/boards/Inkplate6plus.cpp
@@ -96,7 +96,7 @@ bool Inkplate::begin(void)
                     (((i & B11100000) >> 5) << 25);
 #endif
 
-#ifdef ARDUINO_ESP32_DEV
+#ifdef ARDUINO_INKPLATE6
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, HIGH);
 #else
     digitalWriteInternal(IO_INT_ADDR, ioRegsInt, 9, LOW);

--- a/src/include/Mcp.cpp
+++ b/src/include/Mcp.cpp
@@ -16,7 +16,7 @@
  * @authors     Soldered
  ***************************************************/
 
-#if defined(ARDUINO_INKPLATE10) || defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6PLUS)
+#if defined(ARDUINO_INKPLATE10) || defined(ARDUINO_INKPLATE6) || defined(ARDUINO_INKPLATE6PLUS)
 
 #include "Mcp.h"
 

--- a/src/include/System.h
+++ b/src/include/System.h
@@ -77,7 +77,7 @@
 #include "Touch.h"
 #endif
 
-#if defined(ARDUINO_INKPLATE10) || defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6PLUS)
+#if defined(ARDUINO_INKPLATE10) || defined(ARDUINO_INKPLATE6) || defined(ARDUINO_INKPLATE6PLUS)
 #include "Mcp.h"
 #endif
 

--- a/src/include/defines.h
+++ b/src/include/defines.h
@@ -21,7 +21,7 @@
 
 #include "Arduino.h"
 
-#if (defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6V2))
+#if (defined(ARDUINO_INKPLATE6) || defined(ARDUINO_INKPLATE6V2))
 #include "../boards/Inkplate6.h"
 #elif ARDUINO_INKPLATE5
 #include "../boards/Inkplate5.h"


### PR DESCRIPTION
    Change the ARDUINO_ESP32_DEV define to be ARDUINO_INKPLATE6
    to match the other InkPlate board definitions