### PR TITLE
Add drawPngFromBuffer

### DIFF
--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -96,6 +96,8 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
     bool drawJpegFromWeb(const char *url, int x, int y, bool dither = 0, bool invert = 0);
     bool drawJpegFromWeb(WiFiClient *s, int x, int y, int32_t len, bool dither = 0, bool invert = 0);
 
+    bool drawPngFromBuffer(uint8_t *buf, int32_t len, int x, int y, bool dither, bool invert);
+
     bool drawPngFromSd(const char *fileName, int x, int y, bool dither = 0, bool invert = 0);
     bool drawPngFromSd(SdFile *p, int x, int y, bool dither = 0, bool invert = 0);
 

--- a/src/include/ImagePNG.cpp
+++ b/src/include/ImagePNG.cpp
@@ -245,6 +245,53 @@ bool Image::drawPngFromWeb(const char *url, int x, int y, bool dither, bool inve
 }
 
 /**
+ * @brief       drawPngFromBuffer function draws png image from buffer
+ *
+ * @param       int32_t len
+ *              size of buffer
+ * @param       int x
+ *              x position for top left image corner
+ * @param       int y
+ *              y position for top left image corner
+ * @param       bool dither
+ *              1 if using dither, 0 if not
+ * @param       bool invert
+ *              1 if using invert, 0 if not
+ *
+ * @return      1 if drawn successfully, 0 if not
+ */
+bool Image::drawPngFromBuffer(uint8_t *buf, int32_t len, int x, int y, bool dither, bool invert)
+{
+    if (!buf)
+        return 0;
+
+    _pngDither = dither;
+    _pngInvert = invert;
+    lastY = y;
+
+    bool ret = 1;
+
+    if (dither)
+        memset(ditherBuffer, 0, sizeof ditherBuffer);
+
+    pngle_t *pngle = pngle_new();
+    _pngX = x;
+    _pngY = y;
+    pngle_set_draw_callback(pngle, pngle_on_draw);
+
+    if (!buf)
+        return 0;
+
+    if (pngle_feed(pngle, buf, len) < 0)
+        ret = 0;
+
+    pngle_destroy(pngle);
+    free(buf);
+    return ret;
+}
+
+
+/**
  * @brief       drawPngFromWeb function draws png image from sd file
  *
  * @param       WiFiClient *s


### PR DESCRIPTION
Noticed the library has methods to draw bmp and jpg from buffer but not png, so I added it.

Tried it on my Inkplate10 (v1) and behaves identically to `drawPngFromWeb`

Personally I need a function like this as I download png data using a custom function (need to also read HTTP headers) and needed a way to write to the display without drawing again from a URL or SD card.