### PR TITLE
Fix dates displayed in x-axis during year change

### DIFF
--- a/examples/Inkplate10/Projects/Inkplate10_Crypto_Currency_Tracker/Inkplate10_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate10/Projects/Inkplate10_Crypto_Currency_Tracker/Inkplate10_Crypto_Currency_Tracker.ino
@@ -211,7 +211,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate4/Projects/Inkplate4_Crypto_Currency_Tracker/Inkplate4_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate4/Projects/Inkplate4_Crypto_Currency_Tracker/Inkplate4_Crypto_Currency_Tracker.ino
@@ -216,7 +216,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate4TEMPERA/Projects/Inkplate4TEMPERA_Crypto_Currency_Tracker/Inkplate4TEMPERA_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate4TEMPERA/Projects/Inkplate4TEMPERA_Crypto_Currency_Tracker/Inkplate4TEMPERA_Crypto_Currency_Tracker.ino
@@ -232,7 +232,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate5/Projects/Inkplate5_Crypto_Currency_Tracker/Inkplate5_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate5/Projects/Inkplate5_Crypto_Currency_Tracker/Inkplate5_Crypto_Currency_Tracker.ino
@@ -213,7 +213,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate6/Projects/Inkplate6_Crypto_Currency_Tracker/Inkplate6_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate6/Projects/Inkplate6_Crypto_Currency_Tracker/Inkplate6_Crypto_Currency_Tracker.ino
@@ -212,7 +212,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate6COLOR/Projects/Inkplate6COLOR_Crypto_Currency_Tracker/Inkplate6COLOR_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate6COLOR/Projects/Inkplate6COLOR_Crypto_Currency_Tracker/Inkplate6COLOR_Crypto_Currency_Tracker.ino
@@ -208,7 +208,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate6PLUS/Projects/Inkplate6PLUS_Crypto_Currency_Tracker/Inkplate6PLUS_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate6PLUS/Projects/Inkplate6PLUS_Crypto_Currency_Tracker/Inkplate6PLUS_Crypto_Currency_Tracker.ino
@@ -233,7 +233,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");

--- a/examples/Inkplate7/Projects/Inkplate7_Crypto_Currency_Tracker/Inkplate7_Crypto_Currency_Tracker.ino
+++ b/examples/Inkplate7/Projects/Inkplate7_Crypto_Currency_Tracker/Inkplate7_Crypto_Currency_Tracker.ino
@@ -216,7 +216,7 @@ void drawGraph()
     for (int i = 0; i < 5; ++i)
     {
         itoa(((day - i * 7) % 31 + 31) % 31, temp, 10);
-        itoa(month - ((day - i * 7) <= 0), temp + 32, 10);
+        itoa(month - ((day - i * 7) <= 0 ? (month == 1 ? -11 : 1) : 0), temp + 32, 10);
 
         strncpy(dates + 8 * (4 - i), temp, 8);
         strcat(dates + 8 * (4 - i), ".");


### PR DESCRIPTION
* If the current month is early January, December dates on the x-axis were displayed as 0.

I tried fixing it as one-liner. If you think it's messy, I can try to split it into some if-else condition.

**Before**:
![20240109_215514](https://github.com/SolderedElectronics/Inkplate-Arduino-library/assets/865063/45de711c-1c29-4438-9549-20c79df23f1c)

**After**:
![20240109_222450](https://github.com/SolderedElectronics/Inkplate-Arduino-library/assets/865063/ef6e8655-9756-43fa-bcd0-5a628f1c6d60)
