### PR TITLE
Fix incorrect bitwise operation in pixel color calculation

### DIFF
--- a/src/include/ImageBMP.cpp
+++ b/src/include/ImageBMP.cpp
@@ -341,7 +341,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
                 val = ditherGetPixelBmp(px, j, y, w, 1);
             else
             {
-                val = palette[px >> 1] & (px & 1 ? 0x0F : 0xF0) >> (px & 1 ? 0 : 4);
+                val = (palette[px >> 1] & (px & 1 ? 0x0F : 0xF0)) >> (px & 1 ? 0 : 4);
             }
 
 #if defined(ARDUINO_INKPLATECOLOR)
@@ -365,7 +365,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
                 val = ditherGetPixelBmp(px, j, y, w, 1);
             else
             {
-                val = palette[px >> 1] & (px & 1 ? 0x0F : 0xF0) >> (px & 1 ? 0 : 4);
+                val = (palette[px >> 1] & (px & 1 ? 0x0F : 0xF0)) >> (px & 1 ? 0 : 4);
             }
 
 #if defined(ARDUINO_INKPLATECOLOR)


### PR DESCRIPTION
Hey,

I have found that in ImageBMP.cpp, there is a problem with the extraction of colors from the palette array:

For files with 4bit and 8bit color depth, the palette array seems to store two 3bit colors per entry. Depending on the last bit of the color index, a different color should be extracted from it using a shift and an AND operation.

However, the shift operation seems to be done before the AND. Because of this, the lower 3bit color is always returned.
I fixed this by adding an extra pair of parentheses.