### PR TITLE
Add Inkplate2 Peripheral Mode command setTextColor

### DIFF
--- a/examples/Inkplate2/Diagnostics/Inkplate2_Peripheral_Mode/Inkplate2_Peripheral_Mode.ino
+++ b/examples/Inkplate2/Diagnostics/Inkplate2_Peripheral_Mode/Inkplate2_Peripheral_Mode.ino
@@ -71,7 +71,7 @@ void loop()
     {
         if ((e - s) > 0)
         {
-            int x, x1, x2, y, y1, y2, x3, y3, l, c, w, h, r, n, rx, ry, xc, yc;
+            int x, x1, x2, y, y1, y2, x3, y3, l, c, w, h, r, n, rx, ry, xc, yc, fgColor, bgColor;
             char b;
             char temp[150];
             switch (*(s + 1))
@@ -196,6 +196,11 @@ void loop()
                 display.setRotation(c);
                 break;
 
+            case 'H':
+                // Set text and background color
+                sscanf(s + 3, "%d,%d", &fgColor, &bgColor);
+                display.setTextColor(fgColor, bgColor);
+                break;
 
             case 'K':
                 // Clear the display (frame buffer only)


### PR DESCRIPTION
Fixes #266

Without setting text color first, displayed text will be invisible.
Add setTextColor to Peripheral Mode to be able to set text color.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SolderedElectronics/Inkplate-Arduino-library/pull/267?shareId=9bf8b607-d0b0-49b0-a47b-8babf4ac6f62).