### PR TITLE
fixed issue with jpeg images showing in revert color

### DIFF
--- a/src/include/ImageJPEG.cpp
+++ b/src/include/ImageJPEG.cpp
@@ -420,10 +420,14 @@ bool Image::drawJpegChunk(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t
                 val = RGB3BIT(r, g, b);
             }
 
-            if (invert)
-                val = 7 - val;
-            //            if (_imagePtrJpeg->getDisplayMode() == INKPLATE_1BIT)
-            //                val = (~val >> 2) & 1;
+            if (_imagePtrJpeg->getDisplayMode() == INKPLATE_1BIT) {
+                val = (~val >> 2) & 1;
+                if (invert)
+                    val = 1 - val;
+            } else {
+                if (invert)
+                    val = 7 - val;
+            }
 
             _imagePtrJpeg->writePixel(x + i, y + j, val);
 #endif


### PR DESCRIPTION
When I use Black&White mode (1-Bit), the images are being drawn with reverse "colors"

Code I am using to initialize the display:
```
#if GRAYSCALE == 1
Inkplate display(INKPLATE_3BIT);
#else
Inkplate display(INKPLATE_1BIT);
#endif
```

Code I am using to draw image:

`display->drawImage(imgPath.c_str(), x, y, 1, 0);`

Input Image:
<img width="600" height="904" alt="image" src="https://github.com/user-attachments/assets/96eb021a-49c4-4d8c-b50e-3d910e881b07" />

Rendered image:
<img width="540" height="718" alt="image" src="https://github.com/user-attachments/assets/d6f38033-ba2e-426e-9680-76f421a76ae7" />

If I set the "invert" option to 1 and still use 1-BitMode, I get a full black image:
`display->drawImage(imgPath.c_str(), x, y, 1, 1);`

<img width="540" height="718" alt="image" src="https://github.com/user-attachments/assets/e868b5e6-4576-47d3-ab8a-174c65928e3d" />


If I use Grayscale (3-Bit) and use this line of code, the image shows up correctly:

`display->drawImage(imgPath.c_str(), x, y, 1, 0);`

<img width="540" height="718" alt="image" src="https://github.com/user-attachments/assets/771513ab-8d27-4b23-970e-653c484f5125" />

This commit is fixing the issue and prints the images correctly.