### PR TITLE
feat(expander): default MCP INT output to active-HIGH in `begin()`

### DIFF
--- a/src/system/mcpExpander/mcpExpander.cpp
+++ b/src/system/mcpExpander/mcpExpander.cpp
@@ -36,6 +36,22 @@ bool IOExpander::begin(uint8_t _addr)
 
     readMCPRegisters();
 
+    // Configure the INT output for Inkplate-compatible defaults: active-HIGH
+    // polarity, push-pull driver, ports not mirrored. The MCP23017 power-on
+    // default for IOCON is 0x00 (INTPOL=0, active-LOW) which causes the INT
+    // pin to idle HIGH and only drive LOW on an interrupt — the inverse of
+    // what is wanted on the Inkplate boards (and on most host designs that
+    // use the ESP32's ESP_EXT1_WAKEUP_ANY_HIGH for deep-sleep wake). Without
+    // this step the host sees a permanently asserted wake line and exits
+    // deep sleep immediately every cycle.
+    //
+    // v11.0.1 restored the setIntOutput() API but did not call it from
+    // begin(). Setting a sensible default here means the library "just
+    // works" on Inkplate hardware without requiring application code to
+    // know about IOCON. Users with non-default wiring can still override by
+    // calling setIntOutput() after begin().
+    setIntOutput(MCP23017_INT_PORTB, MCP23017_INT_NO_MIRROR, MCP23017_INT_PUSHPULL, MCP23017_INT_ACTHIGH);
+
 #ifdef IO_INT_ADDR
     if (_addr == IO_INT_ADDR)
     {


### PR DESCRIPTION
On Inkplate 6 / 10 / 6PLUS the internal MCP23017's INT pin is wired to
an ESP32 GPIO that's used with `ESP_EXT1_WAKEUP_ANY_HIGH` for deep-sleep
wake. The MCP power-on default for `IOCON` is `0x00` (`INTPOL=0`,
active-LOW) — meaning the INT pin idles HIGH whenever no interrupt is
pending. Result: ext1 wakeup fires immediately on every sleep call,
producing a continuous wake/sleep loop.

v11.0.1 restored the `setIntOutput()` API (good) but doesn't call it
from `begin()`, so the library still doesn't work for deep-sleep wake
out of the box — every application has to know to call
`setIntOutput()` itself.

### Fix

Call `setIntOutput(PORTB, no-mirror, push-pull, active-HIGH)` from
`IOExpander::begin()`. Applications with non-default needs can still
override after `display.begin()`.

### Verification

Inkplate 10 V1, arduino-esp32 3.3.7. Without the patch: device wakes
immediately every sleep cycle. With the patch: device sleeps for the
configured duration; ext1 only fires on real touchpad presses.

### Compat / scope

Backward compatible — only changes a default; existing `setIntOutput()`
callers still win since they run after `begin()`. File is gated to
`ARDUINO_INKPLATE6 || ARDUINO_INKPLATE10 || ARDUINO_INKPLATE6PLUS`, so
no PCAL boards are affected.
