### PR TITLE
fix(Inkplate6COLOR): yield during EPD busy-wait loops

### DIFF
--- a/src/boards/Inkplate6COLOR/Inkplate6COLORDriver.cpp
+++ b/src/boards/Inkplate6COLOR/Inkplate6COLORDriver.cpp
@@ -148,13 +148,13 @@ void EPDDriver::display(bool _leaveOn)
 
     sendCommand(POWER_OFF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        ; // Wait for busy high signal
+        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
     sendCommand(DISPLAY_REF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        ; // Wait for busy high signal
+        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
     sendCommand(0x02);
     while (digitalRead(EPAPER_BUSY_PIN))
-        ; // Wait for busy low signal
+        delay(1); // Wait for busy low signal — yield so the RTOS can breathe
     delay(200);
 
     // Put the panel to sleep again
@@ -220,13 +220,13 @@ void EPDDriver::clean()
 
     sendCommand(POWER_OFF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        ; // Wait for busy high signal
+        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
     sendCommand(DISPLAY_REF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        ; // Wait for busy high signal
+        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
     sendCommand(POWER_OFF_REGISTER);
     while (digitalRead(EPAPER_BUSY_PIN))
-        ; // Wait for busy low signal
+        delay(1); // Wait for busy low signal — yield so the RTOS can breathe
     delay(200);
 }
 

--- a/src/boards/Inkplate6COLOR/Inkplate6COLORDriver.cpp
+++ b/src/boards/Inkplate6COLOR/Inkplate6COLORDriver.cpp
@@ -148,13 +148,13 @@ void EPDDriver::display(bool _leaveOn)
 
     sendCommand(POWER_OFF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy high signal
     sendCommand(DISPLAY_REF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy high signal
     sendCommand(0x02);
     while (digitalRead(EPAPER_BUSY_PIN))
-        delay(1); // Wait for busy low signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy low signal
     delay(200);
 
     // Put the panel to sleep again
@@ -220,13 +220,13 @@ void EPDDriver::clean()
 
     sendCommand(POWER_OFF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy high signal
     sendCommand(DISPLAY_REF_REGISTER);
     while (!(digitalRead(EPAPER_BUSY_PIN)))
-        delay(1); // Wait for busy high signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy high signal
     sendCommand(POWER_OFF_REGISTER);
     while (digitalRead(EPAPER_BUSY_PIN))
-        delay(1); // Wait for busy low signal — yield so the RTOS can breathe
+        delay(1); // Wait for busy low signal
     delay(200);
 }
 


### PR DESCRIPTION
The display() and clean() routines busy-wait on EPAPER_BUSY_PIN with empty loop bodies. Each panel refresh takes 15-30 seconds, during which the calling task monopolises its CPU core. On FreeRTOS multitasking apps this starves IDLE0, the ESP-IDF task watchdog (default 5 s) fires, and the device panic-resets.

Single-task Arduino sketches — the pattern used by the library's own examples — are unaffected because arduino-esp32 auto-feeds the loopTask watchdog after each loop() iteration.

Add delay(1) to each busy-wait loop so the scheduler can run IDLE and other tasks between polls. Loss of polling resolution is negligible (~1 ms on a 20 s operation, well below normal hardware response variance).

This brings Inkplate6COLOR in line with the existing (and correct) pattern already used by Inkplate13SPECTRA's waitForBusy() at src/boards/Inkplate13SPECTRA/Inkplate13SPECTRADriver.cpp:735